### PR TITLE
BXMSDOC-4638-master: Replace all instances of the old file names and anchor IDs to new updated one in Configuring Business Central settings and properties doc.. 

### DIFF
--- a/assemblies/assembly_install-on-eap/main.adoc
+++ b/assemblies/assembly_install-on-eap/main.adoc
@@ -31,7 +31,7 @@ include::{enterprise-dir}/installation/controller-eap-configure-proc.adoc[levelo
 include::{enterprise-dir}/installation/controller-eap-run-proc.adoc[leveloffset=+2]
 
 include::{enterprise-dir}/installation/run-dc-standalone-proc.adoc[leveloffset=+1]
-include::{enterprise-dir}/installation/run-standalone-properties-con.adoc[leveloffset=+2]
+include::{shared-dir}/Workbench/Installation/business-central-system-properties-ref.adoc[leveloffset=+2]
 //== Installing and running {CENTRAL} monitoring
 include::{enterprise-dir}/admin-and-config/maven-repo-using-con.adoc[leveloffset=+1]
 include::{enterprise-dir}/admin-and-config/maven-managing-dependencies-proc.adoc[leveloffset=+2]

--- a/assemblies/assembly_install-on-jws/main.adoc
+++ b/assemblies/assembly_install-on-jws/main.adoc
@@ -41,7 +41,7 @@ include::{enterprise-dir}/installation/jws-kie-server-verify-proc.adoc[leveloffs
 
 include::{enterprise-dir}/installation/controller-jws-install-proc.adoc[leveloffset=+1]
 include::{enterprise-dir}/installation/run-dc-standalone-proc.adoc[leveloffset=+1]
-include::{enterprise-dir}/installation/run-standalone-properties-con.adoc[leveloffset=+2]
+include::{shared-dir}/Workbench/Installation/business-central-system-properties-ref.adoc[leveloffset=+2]
 
 include::{enterprise-dir}/admin-and-config/maven-repo-using-con.adoc[leveloffset=+1]
 include::{enterprise-dir}/admin-and-config/maven-pom-configuration-proc.adoc[leveloffset=+2]

--- a/assemblies/assembly_install-on-tomcat/main.adoc
+++ b/assemblies/assembly_install-on-tomcat/main.adoc
@@ -40,7 +40,7 @@ include::{enterprise-dir}/installation/jws-kie-server-verify-proc.adoc[leveloffs
 
 include::{enterprise-dir}/installation/controller-jws-install-proc.adoc[leveloffset=+1]
 include::{enterprise-dir}/installation/run-dc-standalone-proc.adoc[leveloffset=+1]
-include::{enterprise-dir}/installation/run-standalone-properties-con.adoc[leveloffset=+2]
+include::{shared-dir}/Workbench/Installation/business-central-system-properties-ref.adoc[leveloffset=+2]
 
 include::{enterprise-dir}/admin-and-config/maven-repo-using-con.adoc[leveloffset=+1]
 include::{enterprise-dir}/admin-and-config/maven-pom-configuration-proc.adoc[leveloffset=+2]

--- a/doc-content/enterprise-only/installation/run-dc-standalone-proc.adoc
+++ b/doc-content/enterprise-only/installation/run-dc-standalone-proc.adoc
@@ -100,4 +100,4 @@ java -jar {PRODUCT_FILE}-{URL_COMPONENT_CENTRAL}-standalone.jar -s application-c
 //----
 //+
 //Doing this enables you to deploy containers to {KIE_SERVER}.
-See <<run-standalone-properties-con>> for more information.
+See <<business-central-system-properties-ref>> for more information.

--- a/doc-content/enterprise-only/openshift/offline-repo-proc.adoc
+++ b/doc-content/enterprise-only/openshift/offline-repo-proc.adoc
@@ -12,12 +12,12 @@ endif::[]
 
 = Preparing a Maven mirror repository for offline use
 
-If your 
+If your
 ifdef::offline_onprem[]
-{PRODUCT} deployment 
+{PRODUCT} deployment
 endif::offline_onprem[]
 ifndef::offline_onprem[]
-{OPENSHIFT} environment 
+{OPENSHIFT} environment
 endif::offline_onprem[]
 does not have outgoing access to the public Internet, you must prepare a Maven repository with a mirror of all the necessary artifacts and make this repository available to your environment.
 
@@ -25,10 +25,10 @@ does not have outgoing access to the public Internet, you must prepare a Maven r
 ====
 You do not need to complete this procedure if your
 ifdef::offline_onprem[]
-{PRODUCT} deployment 
+{PRODUCT} deployment
 endif::offline_onprem[]
 ifndef::offline_onprem[]
-{OPENSHIFT} environment 
+{OPENSHIFT} environment
 endif::offline_onprem[]
 is connected to the Internet.
 ====
@@ -97,7 +97,7 @@ ifndef::offline_onprem[]
 endif::offline_onprem[]
 ifdef::offline_onprem[]
 .. Copy the contents of the local Maven cache directory (`~/.m2/repository`) to the temporary directory that you are using.
-. Copy the contents of the temporary directory to a directory on the computer on which you deployed {PRODUCT}. This directory becomes the offline Maven mirror repository. 
+. Copy the contents of the temporary directory to a directory on the computer on which you deployed {PRODUCT}. This directory becomes the offline Maven mirror repository.
 . Create and configure a `settings.xml` file for your {PRODUCT} deployment, according to instructions in
 ifeval::["{context}"=="install-on-eap"]
 <<maven-external-configure-proc_install-on-eap>>.
@@ -109,7 +109,7 @@ ifeval::["{context}"=="install-on-tomcat"]
 <<maven-settings-configuration-ref>>.
 endif::[]
 . Make the following changes in the `settings.xml` file:
-** Under the `<profile>` tag, if a `<repositories>` or `<pluginRepositores>` tag is absent, add the tags as necessary. 
+** Under the `<profile>` tag, if a `<repositories>` or `<pluginRepositores>` tag is absent, add the tags as necessary.
 ** Under `<repositories>` add the following sequence:
 +
 [source,xml]
@@ -146,6 +146,6 @@ Replace `/path/to/repo` with the full path to the local Maven mirror repository 
 Replace `/path/to/repo` with the full path to the local Maven mirror repository directory.
 ifeval::["{context}"=="install-on-eap"]
 +
-. Set the `kie.maven.offline.force` property for {CENTRAL} to `true`. For instructions about setting properties for {CENTRAL}, see <<run-standalone-properties-con>>.
+. Set the `kie.maven.offline.force` property for {CENTRAL} to `true`. For instructions about setting properties for {CENTRAL}, see <<business-central-system-properties-ref>>.
 endif::[]
 endif::offline_onprem[]


### PR DESCRIPTION
**Related Epic and JIRA:**
- [Epic](https://issues.jboss.org/browse/BXMSDOC-4405)
- [JIRA](https://issues.jboss.org/browse/BXMSDOC-4638)

**7.5 Rendered output links:**
- [Configuring Business Central settings and properties RHPAM doc preview](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-4638-CBCS-ChnagedCrossLinks-PAM/#business-central-system-properties-ref)
- [Configuring Business Central settings and properties RHDM doc preview](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-4638-CBCS-ChnagedCrossLinks-DM/#business-central-system-properties-ref)

**Community doc previews:**
- [Drools community doc preview](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-4638-CBCS-ChnagedCrossLinks-DM/#business-central-system-properties-ref)
- [jBPM community doc preview](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-4638-jBPMPreview/#business-central-system-properties-ref)

I have replaced all the instances of **run-standalone-properties-con** with the new **business-central-system-properties-ref**.