### PR TITLE
BXMSDOC-4380-master: user with process-admin role can't see task in Tasks page

### DIFF
--- a/doc-content/enterprise-only/admin-and-config/manage-tasks-con.adoc
+++ b/doc-content/enterprise-only/admin-and-config/manage-tasks-con.adoc
@@ -11,7 +11,7 @@ Process administrators can view and manage all user tasks from the *Tasks* page 
 
 The tasks which are displayed on the *Menu* → *Manage* → *Tasks* page or *Menu* → *Track* → *Task Inbox* page are determined by the current user permissions.
 
-To manage all the tasks, user must be specified as a process administrator by defining any of the this conditions:
+To manage all the tasks, user must be specified as a process administrator by defining any of the following conditions:
 
 * User is specified as `task admin user`. The default value is `Administrator`.
 * User must belong to the task administrators group. The default value is `Administrators`.

--- a/doc-content/enterprise-only/admin-and-config/manage-tasks-con.adoc
+++ b/doc-content/enterprise-only/admin-and-config/manage-tasks-con.adoc
@@ -9,16 +9,16 @@ image::admin-and-config/task-inbox.png[Task inbox]
 
 Process administrators can view and manage all user tasks from the *Tasks* page in {CENTRAL}, located under *Menu* -> *Manage* -> *Tasks*. Users with the `admin` role can access the *Tasks* page but do not have access rights to view and manage tasks by default.
 
-The tasks which are displayed on the *Menu* → *Manage* → *Tasks* page or *Menu* → *Track* → *Task Inbox* page are determined by the current user permissions.
+The tasks that are displayed on the *Menu* → *Manage* → *Tasks* page or *Menu* → *Track* → *Task Inbox* page are determined by the current user permissions.
 
-To manage all the tasks, user must be specified as a process administrator by defining any of the following conditions:
+To manage all the tasks, a user must be specified as a process administrator by defining any of the following conditions:
 
 * User is specified as `task admin user`. The default value is `Administrator`.
 * User must belong to the task administrators group. The default value is `Administrators`.
 
-Both the values can be configured via `org.jbpm.ht.admin.user` and `org.jbpm.ht.admin.group` system properties.
+You can configure the user and user group assignment with the `org.jbpm.ht.admin.user` and `org.jbpm.ht.admin.group` system properties.
 
-To change the default value, open `standalone-full.xml` from the {PRODUCT} installation directory, set the following property under the <system-properties> tag:
+To change the default value of these user system properties, open the `standalone-full.xml` file in the {PRODUCT} installation directory, and set the following property under the <system-properties> tag:
 [source]
 ----
 <system-properties>

--- a/doc-content/enterprise-only/admin-and-config/manage-tasks-con.adoc
+++ b/doc-content/enterprise-only/admin-and-config/manage-tasks-con.adoc
@@ -9,11 +9,27 @@ image::admin-and-config/task-inbox.png[Task inbox]
 
 Users with the `process-admin` role can view and manage all user tasks from the *Tasks* page in {CENTRAL}, located under *Menu* -> *Manage* -> *Tasks*. Users with the `admin` role can access the *Tasks* page but do not have access rights to view and manage tasks by default.
 
+[NOTE]
+=====
+
+The tasks which are displayed on the *Menu* → *Manage* → *Tasks* page or *Menu* → *Track* → *Task Inbox* page are determined by the current user permissions. To display all the tasks in the *Menu* → *Manage* → *Tasks* page, users with `process-admin` role or `admin` role must belong to `Administrators` group.
+
+To assign users to `Administrators` group, open `standalone-full.xml` from the {PRODUCT} installation directory, set the following property under the <system-properties> tag:
+
+[source]
+----
+<system-properties>
+        ...
+        <property name="org.jbpm.ht.admin.group" value="admin"/>
+    </system-properties>
+----
+=====
+
 You can open, view, and modify the details of a task, such as the due date, the priority, or the task description, by clicking a task in the list. The following tabs are available in the task page:
 
 image::admin-and-config/task-details.png[Task details]
 
-* *Work*: Displays basic details about the task and the task owner. You can click the *Claim* button to claim the task. To undo the claim process, click the *Release* button. 
+* *Work*: Displays basic details about the task and the task owner. You can click the *Claim* button to claim the task. To undo the claim process, click the *Release* button.
 * *Details*: Displays information such as task description, status, and due date.
 * *Assignments*: Displays the current owner of the task and enables you to delegate the task to another person or group.
 * *Comments*: Displays comments added by task user(s). You can delete an existing comment and add a new comment.

--- a/doc-content/enterprise-only/admin-and-config/manage-tasks-con.adoc
+++ b/doc-content/enterprise-only/admin-and-config/manage-tasks-con.adoc
@@ -7,15 +7,18 @@ A user task can be assigned to a particular user, multiple users, or to a group.
 
 image::admin-and-config/task-inbox.png[Task inbox]
 
-Users with the `process-admin` role can view and manage all user tasks from the *Tasks* page in {CENTRAL}, located under *Menu* -> *Manage* -> *Tasks*. Users with the `admin` role can access the *Tasks* page but do not have access rights to view and manage tasks by default.
+Process administrators can view and manage all user tasks from the *Tasks* page in {CENTRAL}, located under *Menu* -> *Manage* -> *Tasks*. Users with the `admin` role can access the *Tasks* page but do not have access rights to view and manage tasks by default.
 
-[NOTE]
-=====
+The tasks which are displayed on the *Menu* → *Manage* → *Tasks* page or *Menu* → *Track* → *Task Inbox* page are determined by the current user permissions.
 
-The tasks which are displayed on the *Menu* → *Manage* → *Tasks* page or *Menu* → *Track* → *Task Inbox* page are determined by the current user permissions. To display all the tasks in the *Menu* → *Manage* → *Tasks* page, users with `process-admin` role or `admin` role must belong to `Administrators` group.
+To manage all the tasks, user must be specified as a process administrator by defining any of the this conditions:
 
-To assign users to `Administrators` group, open `standalone-full.xml` from the {PRODUCT} installation directory, set the following property under the <system-properties> tag:
+* User is specified as `task admin user`. The default value is `Administrator`.
+* User must belong to the task administrators group. The default value is `Administrators`.
 
+Both the values can be configured via `org.jbpm.ht.admin.user` and `org.jbpm.ht.admin.group` system properties.
+
+To change the default value, open `standalone-full.xml` from the {PRODUCT} installation directory, set the following property under the <system-properties> tag:
 [source]
 ----
 <system-properties>
@@ -23,7 +26,7 @@ To assign users to `Administrators` group, open `standalone-full.xml` from the {
         <property name="org.jbpm.ht.admin.group" value="admin"/>
     </system-properties>
 ----
-=====
+
 
 You can open, view, and modify the details of a task, such as the due date, the priority, or the task description, by clicking a task in the list. The following tabs are available in the task page:
 

--- a/doc-content/enterprise-only/admin-and-config/manage-tasks-con.adoc
+++ b/doc-content/enterprise-only/admin-and-config/manage-tasks-con.adoc
@@ -7,26 +7,14 @@ A user task can be assigned to a particular user, multiple users, or to a group.
 
 image::admin-and-config/task-inbox.png[Task inbox]
 
-Process administrators can view and manage all user tasks from the *Tasks* page in {CENTRAL}, located under *Menu* -> *Manage* -> *Tasks*. Users with the `admin` role can access the *Tasks* page but do not have access rights to view and manage tasks by default.
-
-The tasks that are displayed on the *Menu* → *Manage* → *Tasks* page or *Menu* → *Track* → *Task Inbox* page are determined by the current user permissions.
+Business administrators can view and manage all user tasks from the *Tasks* page in {CENTRAL}, located under *Menu* -> *Manage* -> *Tasks*. Users with the `admin` or `process-admin` role can access the *Tasks* page but do not have access rights to view and manage tasks by default.
 
 To manage all the tasks, a user must be specified as a process administrator by defining any of the following conditions:
 
 * User is specified as `task admin user`. The default value is `Administrator`.
-* User must belong to the task administrators group. The default value is `Administrators`.
+* User belongs to the task administrators group. The default value is `Administrators`.
 
 You can configure the user and user group assignment with the `org.jbpm.ht.admin.user` and `org.jbpm.ht.admin.group` system properties.
-
-To change the default value of these user system properties, open the `standalone-full.xml` file in the {PRODUCT} installation directory, and set the following property under the <system-properties> tag:
-[source]
-----
-<system-properties>
-        ...
-        <property name="org.jbpm.ht.admin.group" value="admin"/>
-    </system-properties>
-----
-
 
 You can open, view, and modify the details of a task, such as the due date, the priority, or the task description, by clicking a task in the list. The following tabs are available in the task page:
 


### PR DESCRIPTION
- [Associated JIRA](https://issues.jboss.org/browse/BXMSDOC-4380)
- [Managing & monitoring business processes in RHPAM doc preview](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-4380-MMBP-FP/#manage-tasks-con-managing-and-monitoring-processes)

Can you please review and verify the small section which I have added in Chapter 4. Task management? 