### PR TITLE
BXMSDOC-4890-master: Update managing & monitoring Process/Decision server doc for PAM/DM 7.6

### DIFF
--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/kie-server-system-properties-ref.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/kie-server-system-properties-ref.adoc
@@ -358,4 +358,9 @@ endif::[]
 |String
 |`org.drools.persistence.jpa.KnowledgeStoreServiceImpl`
 |Fully qualified name of the class that implements `KieStoreServices` that are responsible for bootstrapping KieSession instances.
+
+|`org.kie.server.strict.id.format`
+|`true`, `false`
+|`false`
+|While using JSON marshalling, if the property is set to `true`, the JSON response is wrapped. It will return a response in the proper JSON format. For example, *{"value" : 1}*.
 |===

--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/kie-server-system-properties-ref.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/kie-server-system-properties-ref.adoc
@@ -362,5 +362,10 @@ endif::[]
 |`org.kie.server.strict.id.format`
 |`true`, `false`
 |`false`
-|While using JSON marshalling, if the property is set to `true`, the JSON response is wrapped. It will return a response in the proper JSON format. For example, *{"value" : 1}*.
+|The following options are available:
+
+* While using JSON marshalling, if the property is set to `true`, it will always return a response in the proper JSON format. For example, *{"value" : 1}*.
+
+* When the property is set to `false`, a JSON response is wrapped if the original response contains only a single number.
+
 |===


### PR DESCRIPTION
**JIRA:**
- [Epic](https://issues.redhat.com/browse/BXMSDOC-4890)
- [Dedicated JIRA](https://issues.redhat.com/browse/BXMSDOC-4892)

**7.6 doc previews:**
- [Managing and monitoring Process Server](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-4890-RHPAM-MMPS/#kie-server-extensions-con_execution-server)
- [Managing and monitoring Decision Server](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-4890-RHDM-MMPS/#kie-server-extensions-con_execution-server)

**Community doc previews:**
- [Drools Document](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-DROOLS-KSSystemProperty/#kie-server-system-properties-ref_kie-apis)
- [jBPM Document](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-jBPM-KSSystemProperty/#kie-server-system-properties-ref_kie-apis)

For RHPAM --> Chapter 23: Please check **org.kie.server.strict.id.format** property in the Table 22.7. Other system properties.
For RHDM --> Chapter 17: Please check **org.kie.server.strict.id.format** property in the Table 17.4. Other system properties.