### PR TITLE
BXMSDOC-5141-master: Resolved some typos, outdated content from the kie server and test scenario documents

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-background-rule-based-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-background-rule-based-proc.adoc
@@ -16,7 +16,6 @@ Follow the procedure below to add and set a background data in rule-based test s
 . Select a property header cell to add a background data object field.
 . From the *Test Tools* panel, select the data object.
 . Click *Insert Data Object*.
-. Optional: Click *Clear selection* to remove the selected data object.
 . To add more properties to the data object, right-click the property header cell and select *Insert column right* or *Insert column left* as required.
 . Use the contextual menu to add or remove columns and rows as needed.
 . Run the defined test scenarios.

--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/kie-server-system-properties-ref.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/kie-server-system-properties-ref.adoc
@@ -362,10 +362,5 @@ endif::[]
 |`org.kie.server.strict.id.format`
 |`true`, `false`
 |`false`
-|The following options are available:
-
-* While using JSON marshalling, if the property is set to `true`, it will always return a response in the proper JSON format. For example, *{"value" : 1}*.
-
-* When the property is set to `false`, a JSON response is wrapped if the original response contains only a single number.
-
+|While using JSON marshalling, if the property is set to `true`, it will always return a response in the proper JSON format. For example, if the original response contains only a single number, then the response is wrapped in a JSON format. For example, *{"value" : 1}*.
 |===


### PR DESCRIPTION
**7.6 doc previews:** 
- [RHPAM 7.6: Testing a decision service using test scenarios](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-5141-Changes-TS-RHPAM/)
- [RHDM 7.6: Testing a decision service using test scenarios](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-5141-Changes-TS-RHDM/)

- [RHPAM 7.6: Managing and monitoring process server](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-5141-Changes-MMPS-RHPAM/)
- [RHDM 7.6: Managing and monitoring decision server](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-5141-Changes-MMPS-RHDM/)

**Community doc previews:**
- [Drools document for kie server](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-5141-Drools-Changes/#kie-server-system-properties-ref_kie-apis)
- [jBPM document](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-5141-jBPM-Changes/#kie-server-system-properties-ref_kie-apis)


Corrected the system property description and outdated content from managing and monitoring kie server and test scenario doc.