### PR TITLE
BXMSDOC-5115-master: Added a note regarding validation of list in legacy test scenario content.

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-legacy-EXPECT-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-legacy-EXPECT-proc.adoc
@@ -26,7 +26,7 @@ image::project-data/test-scenario-field-value.png[Modify a fact field]
 +
 . Set the field values to what is expected to be valid as a result of the *GIVEN* input (such as `approved` | `equals` | `false`).
 +
-NOTE: In the legacy test scenarios designer, you can use the `=["value1", "value2"]` string format in the *EXPECT* field to validate the list of strings.
+NOTE: In the legacy test scenarios designer, you can use `=["value1", "value2"]` string format in the *EXPECT* field to validate the list of strings.
 
 . Continue adding any other *EXPECT* input data for the scenario and click *Save* in the test scenarios designer to save your work.
 . After you have defined and saved all *GIVEN*, *EXPECT*, and other data for the scenario, click *Run scenario* in the upper-right corner to run this `.scenario` file, or click *Run all scenarios* to run all saved `.scenario` files in the project package (if there are multiple). Although the *Run scenario* option does not require the individual `.scenario` file to be saved, the *Run all scenarios* option does require all `.scenario` files to be saved.

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-legacy-EXPECT-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-legacy-EXPECT-proc.adoc
@@ -26,7 +26,7 @@ image::project-data/test-scenario-field-value.png[Modify a fact field]
 +
 . Set the field values to what is expected to be valid as a result of the *GIVEN* input (such as `approved` | `equals` | `false`).
 +
-NOTE: In the legacy test scenarios designer, you can use `=["value1", "value2"]` string format in the *EXPECT* field to validate the list of strings.
+NOTE: In the legacy test scenarios designer, you can use `["value1", "value2"]` string format in the *EXPECT* field to validate the list of strings.
 
 . Continue adding any other *EXPECT* input data for the scenario and click *Save* in the test scenarios designer to save your work.
 . After you have defined and saved all *GIVEN*, *EXPECT*, and other data for the scenario, click *Run scenario* in the upper-right corner to run this `.scenario` file, or click *Run all scenarios* to run all saved `.scenario` files in the project package (if there are multiple). Although the *Run scenario* option does not require the individual `.scenario` file to be saved, the *Run all scenarios* option does require all `.scenario` files to be saved.

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-legacy-EXPECT-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-legacy-EXPECT-proc.adoc
@@ -6,6 +6,8 @@ The *EXPECT* section defines the expected results based on the *GIVEN* input fac
 .Prerequisites
 * All data objects required for your test scenario have been created or imported and are listed in the *Data Objects* tab of the *Test Scenarios (Legacy)* designer.
 
+NOTE: In the legacy test scenarios designer, you can use the `=["value1", "value2"]` string format in the *EXPECT* field to validate the list of strings.
+
 .Procedure
 . In the *Test Scenarios (Legacy)* designer, click *EXPECT* to open the *New expectation* window with the available facts.
 +

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-legacy-EXPECT-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-legacy-EXPECT-proc.adoc
@@ -6,8 +6,6 @@ The *EXPECT* section defines the expected results based on the *GIVEN* input fac
 .Prerequisites
 * All data objects required for your test scenario have been created or imported and are listed in the *Data Objects* tab of the *Test Scenarios (Legacy)* designer.
 
-NOTE: In the legacy test scenarios designer, you can use the `=["value1", "value2"]` string format in the *EXPECT* field to validate the list of strings.
-
 .Procedure
 . In the *Test Scenarios (Legacy)* designer, click *EXPECT* to open the *New expectation* window with the available facts.
 +
@@ -27,6 +25,9 @@ The list includes the following options, depending on the data in the *GIVEN* se
 image::project-data/test-scenario-field-value.png[Modify a fact field]
 +
 . Set the field values to what is expected to be valid as a result of the *GIVEN* input (such as `approved` | `equals` | `false`).
++
+NOTE: In the legacy test scenarios designer, you can use the `=["value1", "value2"]` string format in the *EXPECT* field to validate the list of strings.
+
 . Continue adding any other *EXPECT* input data for the scenario and click *Save* in the test scenarios designer to save your work.
 . After you have defined and saved all *GIVEN*, *EXPECT*, and other data for the scenario, click *Run scenario* in the upper-right corner to run this `.scenario` file, or click *Run all scenarios* to run all saved `.scenario` files in the project package (if there are multiple). Although the *Run scenario* option does not require the individual `.scenario` file to be saved, the *Run all scenarios* option does require all `.scenario` files to be saved.
 +


### PR DESCRIPTION
- [Dedicated JIRA](https://issues.redhat.com/browse/BXMSDOC-5115)
- [7.7-RHPAM-Testing a decision service using test scenarios](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-5115-RHPAM-TS-CustomerTicket-Final/#test-scenarios-legacy-EXPECT-proc)
- [7.7-RHDM-Testing a decision service using test scenarios](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-5115-RHDM-TS-CustomerTicket-Final/#test-scenarios-legacy-EXPECT-proc)

Added a note regarding the validation of list in the **16.1.2. Adding EXPECT results in test scenarios (legacy)** section in **step 4**.

Can you please review and verify the content?

