### PR TITLE
BXMSDOC-5811-master: Add reference links for what's new content in 7.7 release notes

### DIFF
--- a/assemblies/assembly_release-notes/main.adoc
+++ b/assemblies/assembly_release-notes/main.adoc
@@ -27,11 +27,5 @@ include::{enterprise-dir}/release-notes/rn-known-issues-ref.adoc[leveloffset=+1]
 
 include::{enterprise-dir}/release-notes/rn-770-fixed-issues-ref.adoc[leveloffset=+1]
 
-
-
-
-
-
-
 // Versioning info
 include::_artifacts/versioning-information.adoc[]

--- a/doc-content/enterprise-only/release-notes/rn-tech-preview-ref.adoc
+++ b/doc-content/enterprise-only/release-notes/rn-tech-preview-ref.adoc
@@ -13,6 +13,13 @@ For more information on Red Hat Technology Preview features, see https://access.
 == {OPENSHIFT} 4.x deployment on restricted networks
 You can use Operator Lifecycle Management to deploy {PRODUCT} on {OPENSHIFT} 4.x on restricted networks that do not have a connection to the public Internet.
 
+ifdef::PAM[]
+For more information about deployment in a restricted network, see https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.7/html/deploying_a_red_hat_process_automation_manager_environment_on_red_hat_openshift_container_platform_using_operators/dm-openshift-prepare-con#restricted-network-proc[Deploying a Red Hat Process Automation Manager environment on Red Hat OpenShift Container Platform using Operators].
+endif::PAM[]
+ifdef::DM[]
+For more information about deployment in a restricted network, see https://access.redhat.com/documentation/en-us/red_hat_decision_manager/7.7/html-single/deploying_a_red_hat_decision_manager_environment_on_red_hat_openshift_container_platform_using_operators/index#restricted-network-proc[Deploying a Red Hat Decision Manager environment on Red Hat OpenShift Container Platform using Operators].
+endif::DM[]
+
 == Deploying a high-availability authoring environment on {OPENSHIFT} 4.x
 You can deploy a high-availability {PRODUCT} authoring environment on {OPENSHIFT} 4.x using the operator.
 

--- a/doc-content/enterprise-only/release-notes/rn-whats-new-con.adoc
+++ b/doc-content/enterprise-only/release-notes/rn-whats-new-con.adoc
@@ -192,7 +192,7 @@ For more information, see https://access.redhat.com/documentation/en-us/red_hat_
 endif::PAM[]
 ifdef::DM[]
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_decision_manager/7.7/html-single/creating_red_hat_decision_manager_business_applications_with_spring_boot/index[Creating Red Hat Decision Manager business applications with Spring Boot].
-ifdef::DM[]
+endif::DM[]
 
 === SolverManager
 

--- a/doc-content/enterprise-only/release-notes/rn-whats-new-con.adoc
+++ b/doc-content/enterprise-only/release-notes/rn-whats-new-con.adoc
@@ -23,12 +23,26 @@ Maven archetype support is now available in {CENTRAL}. To access this functional
 * You can use them as a template when creating a new project in {CENTRAL}.
 * To manage all available archetypes in spaces, go to *Design* -> *<your_space>* -> *Settings* in {CENTRAL}.
 
+ifdef::PAM[]
+For more information about archetypes management, see https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.7/html-single/configuring_business_central_settings_and_properties/index#managing-business-central-archetype-con[Configuring Business Central settings and properties].
+endif::PAM[]
+ifdef::DM[]
+For more information about archetypes management, see https://access.redhat.com/documentation/en-us/red_hat_decision_manager/7.7/html-single/configuring_business_central_settings_and_properties/index#managing-business-central-archetype-con[Configuring Business Central settings and properties].
+endif::DM[]
+
 === Test Scenarios
 
 The test scenarios designer in {CENTRAL} is now available with the new features supported in {PRODUCT} {PRODUCT_VERSION}.
 
 * In DMN-based as well as rule-based test scenarios, it is now possible to define the value of a collection like a list or a map by using an expression in both *GIVEN* and *EXPECT* columns. To add an expression,  you can now choose *Define list* from the collection editor.
 * You can now use the {KIE_SERVER} REST API to execute the test scenarios externally. It executes the test scenarios against the deployed project. This functionality is disabled by default, use `org.kie.scenariosimulation.server.ext.disabled` system property to enable it.
+
+ifdef::PAM[]
+For more information about test scenarios designer in {CENTRAL}, see https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.7/html-single/testing_a_decision_service_using_test_scenarios/index#test-designer-list-map-add-remove-item-proc[Testing a decision service using test scenarios].
+endif::PAM[]
+ifdef::DM[]
+For more information about test scenarios designer in {CENTRAL}, see https://access.redhat.com/documentation/en-us/red_hat_decision_manager/7.7/html-single/testing_a_decision_service_using_test_scenarios/index#test-designer-list-map-add-remove-item-proc[Testing a decision service using test scenarios].
+endif::DM[]
 
 === Ability to create a project from empty repositories
 
@@ -37,6 +51,12 @@ You can now create a new project in {CENTRAL} by importing an empty GitHub or Gi
 === Squash commit on change requests
 
 You can now squash multiple commits into a single commit and add the commit to a target branch for a change request.
+ifdef::PAM[]
+For more information about change requests in {CENTRAL}, see https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.7/html/managing_projects_in_business_central/change-requests-con_managing-projects#reviewing-change-requests-proc_managing-projects[Managing projects in Business Central].
+endif::PAM[]
+ifdef::DM[]
+For more information about change requests in {CENTRAL}, see https://access.redhat.com/documentation/en-us/red_hat_decision_manager/7.7/html/managing_projects_in_business_central/change-requests-con_managing-projects#reviewing-change-requests-proc_managing-projects[Managing projects in Business Central].
+endif::DM[]
 
 ifdef::PAM[]
 
@@ -46,6 +66,8 @@ The process instance page in {CENTRAL} is now available with new navigation feat
 
 * In the *Instance Details* tab, you can now click the *Parent Process Instance ID* field to navigate to the parent *Instance Details* tab.
 * In the *Diagram* tab, you can now see a new menu containing links of the parent process and subprocess to navigate between the subprocess and parent process *Diagram* tab.
+
+For more information about process instance management, see https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.7/html/managing_and_monitoring_business_processes_in_business_central/process-instance-details-con-managing-and-monitoring-processes[Managing and monitoring business processes in Business Central].
 
 endif::PAM[]
 
@@ -109,6 +131,13 @@ Deploy a specific branch in a specific project and space. If `branchName` is not
 [POST] /spaces/{spaceName}/projects/{projectName}/branches/{branchName}/maven/deploy::
 ----
 
+ifdef::PAM[]
+For more information about REST API for {CENTRAL} spaces and projects, see https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.7/html-single/interacting_with_red_hat_process_automation_manager_using_kie_apis/index#knowledge-store-rest-api-branches-ref_kie-apis[Interacting with Red Hat Process Automation Manager using KIE APIs].
+endif::PAM[]
+ifdef::DM[]
+For more information about REST API for {CENTRAL} spaces and projects, see https://access.redhat.com/documentation/en-us/red_hat_decision_manager/7.7/html-single/interacting_with_red_hat_decision_manager_using_kie_apis/index#knowledge-store-rest-api-branches-ref_kie-apis[Interacting with Red Hat Decision Manager using KIE APIs].
+endif::DM[]
+
 === Support for DMN 1.3
 
 {PRODUCT} {PRODUCT_VERSION} is now DMN 1.3 ready.
@@ -158,6 +187,13 @@ endif::[]
 now includes a Spring Boot starter. You can use the Spring Boot starter to avoid common issues with class loading and use `application.properties` to overwrite the solver configuration. The `solverConfig.xml` file is no longer required because the starter automatically detects `@PlanningSolution` and `@PlanningEntity` annotations.
 The constraint streams API is improved. You can now modify your streams using the `groupBy()` building block.
 
+ifdef::PAM[]
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.7/html-single/creating_red_hat_process_automation_manager_business_applications_with_spring_boot/index[Creating Red Hat Process Automation Manager business applications with Spring Boot].
+endif::PAM[]
+ifdef::DM[]
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_decision_manager/7.7/html-single/creating_red_hat_decision_manager_business_applications_with_spring_boot/index[Creating Red Hat Decision Manager business applications with Spring Boot].
+ifdef::DM[]
+
 === SolverManager
 
 You can use SolverManager as wrapper for one or more Solver instances to simplify planning REST API and other enterprise services. The `solve(…​)` methods differ from the normal `Solver.solve(…​)` method:
@@ -192,9 +228,23 @@ public class TimeTableService {
 
 When deploying {PRODUCT} on {OPENSHIFT} using the operator, you can configure Git hooks to enable interaction between the built in Git repository of {CENTRAL} and other repositories.
 
+ifdef::PAM[]
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.7/html/deploying_a_red_hat_process_automation_manager_environment_on_red_hat_openshift_container_platform_using_operators/operator-con#operator-deploy-central-proc[Deploying a Red Hat Process Automation Manager environment on Red Hat OpenShift Container Platform using Operators].
+endif::PAM[]
+ifdef::DM[]
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_decision_manager/7.7/html-single/deploying_a_red_hat_decision_manager_environment_on_red_hat_openshift_container_platform_using_operators/index#operator-deploy-central-proc[Deploying a Red Hat Decision Manager environment on Red Hat OpenShift Container Platform using Operators].
+endif::DM[]
+
 === Support for role mapping in operator deployment on {OPENSHIFT}
 
 When deploying {PRODUCT} on {OPENSHIFT} using the operator and using RH-SSO or LDAP authentication, you can configure role mapping to link roles defined in {PRODUCT} to different roles defined in RH-SSO or LDAP.
+
+ifdef::PAM[]
+For more information about role mapping in operator deployment on {OPENSHIFT}, see https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.7/html/deploying_a_red_hat_process_automation_manager_environment_on_red_hat_openshift_container_platform_using_operators/operator-con#operator-deploy-security-proc[Deploying a Red Hat Process Automation Manager environment on Red Hat OpenShift Container Platform using Operators].
+endif::PAM[]
+ifdef::DM[]
+For more information about role mapping in operator deployment on {OPENSHIFT}, see https://access.redhat.com/documentation/en-us/red_hat_decision_manager/7.7/html/deploying_a_red_hat_decision_manager_environment_on_red_hat_openshift_container_platform_using_operators/operator-con#operator-deploy-security-proc[Deploying a Red Hat Decision Manager environment on Red Hat OpenShift Container Platform using Operators].
+endif::DM[]
 
 ifdef::PAM[]
 
@@ -202,27 +252,58 @@ ifdef::PAM[]
 
 When deploying {PRODUCT} on {OPENSHIFT} using the operator and configuring a {KIE_SERVER} to use an external database server, you can configure the use of an Oracle, Sybase, DB2, or MS SQL server.
 
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.7/html/deploying_a_red_hat_process_automation_manager_environment_on_red_hat_openshift_container_platform_using_operators/operator-con#operator-deploy-kieserver-proc[Deploying a Red Hat Process Automation Manager environment on Red Hat OpenShift Container Platform using Operators].
+
 endif::PAM[]
 
 === Support for JVM configuration in operator deployment on {OPENSHIFT}
 
 When deploying {PRODUCT} on {OPENSHIFT} using the operator, you can set custom JVM configuration for {CENTRAL} and {KIE_SERVER} pods.
 
+ifdef::PAM[]
+For more information about JVM configuration in operator deployment on {OPENSHIFT}, see https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.7/html/deploying_a_red_hat_process_automation_manager_environment_on_red_hat_openshift_container_platform_using_operators/operator-con#operator-deploy-central-proc[Deploying a Red Hat Process Automation Manager environment on Red Hat OpenShift Container Platform using Operators].
+endif::PAM[]
+ifdef::DM[]
+For more information about JVM configuration in operator deployment on {OPENSHIFT}, see https://access.redhat.com/documentation/en-us/red_hat_decision_manager/7.7/html/deploying_a_red_hat_decision_manager_environment_on_red_hat_openshift_container_platform_using_operators/operator-con#operator-deploy-central-proc[Deploying a Red Hat Decision Manager environment on Red Hat OpenShift Container Platform using Operators].
+endif::DM[]
+
 === Deploying an authoring environment on {OPENSHIFT} without ReadWriteMany support
 
 When deploying {PRODUCT} on {OPENSHIFT}, you can deploy an authoring environment if your {OPENSHIFT} infrastructure does not provision persistent modules that support the ReadWriteMany mode.
+
+ifdef::PAM[]
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.7/html/deploying_a_red_hat_process_automation_manager_authoring_environment_on_red_hat_openshift_container_platform/index[Deploying a Red Hat Process Automation Manager authoring environment on Red Hat OpenShift Container Platform].
+endif::PAM[]
 
 === A single built-in user account for communication between {CENTRAL} and {KIE_SERVER}
 
 {PRODUCT} now uses a single built-in administrative user account for communication between {CENTRAL} and {KIE_SERVER}. You no longer need to configure multiple built-in user accounts.
 
+ifdef::PAM[]
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.7/html/deploying_a_red_hat_process_automation_manager_authoring_environment_on_red_hat_openshift_container_platform/dm-openshift-prepare-con#secret-adminuser-create-proc[Deploying a Red Hat Process Automation Manager authoring environment on Red Hat OpenShift Container Platform].
+endif::PAM[]
+
 === Support for concurrent service deployment on a {KIE_SERVER} in a {PRODUCT} authoring environment on {OPENSHIFT}
 
 If you deploy a {PRODUCT} authoring environment on {OPENSHIFT} 3.x using templates, you can deploy several services on the same {KIE_SERVER} concurrently, without needing to wait for a deployment to complete before you can start the next deployment. This functionality is provided by the *ControllerBasedStartupStrategy* setting that applies to communication between {CENTRAL} and {KIE_SERVER}. You can also enable this strategy when deploying on {OPENSHIFT} 4.x using the operator.
 
+ifdef::PAM[]
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.7/html/deploying_a_red_hat_process_automation_manager_authoring_environment_on_red_hat_openshift_container_platform/environment-authoring-con[Deploying a Red Hat Process Automation Manager authoring environment on Red Hat OpenShift Container Platform].
+endif::PAM[]
+ifdef::DM[]
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_decision_manager/7.7/html/deploying_a_red_hat_decision_manager_authoring_or_managed_server_environment_on_red_hat_openshift_container_platform/environment-authoring-con[Deploying a Red Hat Decision Manager authoring or managed server environment on Red Hat OpenShift Container Platform].
+endif::DM[]
+
 === Support for deploying {PRODUCT} on {OPENSHIFT} 4.3
 
 Deploying {PRODUCT} using the operator on {OPENSHIFT} 4.3 is now supported.
+
+ifdef::PAM[]
+For more information about deploying {PRODUCT} on {OPENSHIFT} 4.3, see https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.7/html/deploying_a_red_hat_process_automation_manager_environment_on_red_hat_openshift_container_platform_using_operators/index[Deploying a Red Hat Process Automation Manager environment on Red Hat OpenShift Container Platform using Operators].
+endif::PAM[]
+ifdef::DM[]
+For more information about deploying {PRODUCT} on {OPENSHIFT} 4.3, see https://access.redhat.com/documentation/en-us/red_hat_decision_manager/7.7/html/deploying_a_red_hat_decision_manager_environment_on_red_hat_openshift_container_platform_using_operators/index[Deploying a Red Hat Decision Manager environment on Red Hat OpenShift Container Platform using Operators].
+endif::DM[]
 
 === {EAP} version updated to 7.2.6
 


### PR DESCRIPTION
- [Dedicated JIRA](https://issues.redhat.com/browse/BXMSDOC-5811)
- [7.7-RHPAM-Release notes for Red Hat Process Automation Manager](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-2608-RHPAM-7.7-RN/) 
- [7.7-RHDM-Release notes for Red Hat Decision Manager](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-2608-RHDM-7.7-RN/) 

I have added the reference links in the **What's new** and **tech preview** section of the RN document.