### PR TITLE
BXMSDOC-6504: Document how to make LRUCache configurable to avoid large memory retention.

### DIFF
--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Installation/business-central-system-properties-ref.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Installation/business-central-system-properties-ref.adoc
@@ -123,6 +123,7 @@ NOTE: Use this property for {CENTRAL} only. If you share a runtime environment w
 * `org.guvnor.m2repo.dir`: Place where the Maven repository folder is stored. Default value: `<working-directory>/repositories/kie`.
 * `org.guvnor.project.gav.check.disabled`: Disables group ID, artifact ID, and version (GAV) checks. Default value: `false`.
 * `org.kie.build.disable-project-explorer`: Disables automatic build of a selected project in Project Explorer. Default value: `false`.
+* `org.kie.builder.cache.size`: Defines the cache size of the project builder. We can restrict the cache size using this property. Default value: `20`.
 * `org.kie.verification.disable-dtable-realtime-verification`: Disables the real-time validation and verification of decision tables. Default value: `false`.
 
 {CONTROLLER}::

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Installation/business-central-system-properties-ref.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Installation/business-central-system-properties-ref.adoc
@@ -123,7 +123,7 @@ NOTE: Use this property for {CENTRAL} only. If you share a runtime environment w
 * `org.guvnor.m2repo.dir`: Place where the Maven repository folder is stored. Default value: `<working-directory>/repositories/kie`.
 * `org.guvnor.project.gav.check.disabled`: Disables group ID, artifact ID, and version (GAV) checks. Default value: `false`.
 * `org.kie.build.disable-project-explorer`: Disables automatic build of a selected project in Project Explorer. Default value: `false`.
-* `org.kie.builder.cache.size`: Defines the cache size of the project builder. We can configure the cache size using this property. Default value: `20`.
+* `org.kie.builder.cache.size`: Defines the cache size of the project builder. Default value: `20`.
 * `org.kie.verification.disable-dtable-realtime-verification`: Disables the real-time validation and verification of decision tables. Default value: `false`.
 
 {CONTROLLER}::

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Installation/business-central-system-properties-ref.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Installation/business-central-system-properties-ref.adoc
@@ -123,7 +123,7 @@ NOTE: Use this property for {CENTRAL} only. If you share a runtime environment w
 * `org.guvnor.m2repo.dir`: Place where the Maven repository folder is stored. Default value: `<working-directory>/repositories/kie`.
 * `org.guvnor.project.gav.check.disabled`: Disables group ID, artifact ID, and version (GAV) checks. Default value: `false`.
 * `org.kie.build.disable-project-explorer`: Disables automatic build of a selected project in Project Explorer. Default value: `false`.
-* `org.kie.builder.cache.size`: Defines the cache size of the project builder. We can restrict the cache size using this property. Default value: `20`.
+* `org.kie.builder.cache.size`: Defines the cache size of the project builder. We can configure the cache size using this property. Default value: `20`.
 * `org.kie.verification.disable-dtable-realtime-verification`: Disables the real-time validation and verification of decision tables. Default value: `false`.
 
 {CONTROLLER}::


### PR DESCRIPTION
**JIRAs:**
- [Epic](https://issues.redhat.com/browse/BXMSDOC-6276)
- [Dedicated JIRA](https://issues.redhat.com/browse/BXMSDOC-6504)
- [RHPAM-2808](https://issues.redhat.com/browse/RHPAM-2808)

**Doc previews:** 
- [RHPAM-II. Configuring Business Central settings and properties](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-6504-RHPAM-BCSettings/#business-central-system-properties-ref_configuring-central)
- [RHDM-II. Configuring Business Central settings and properties](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-6504-RHDM-BCSettings/#business-central-system-properties-ref_configuring-central)

**Doc impact:**
- For RHPAM: Under **II. Configuring Business Central settings and properties** --> Chapter 49. Business Central system properties --> Section Maven and miscellaneous
- For RHDM: Under **II. Configuring Business Central settings and properties** --> Chapter 43. Business Central system properties --> Section Maven and miscellaneous

