### PR TITLE
PR for BXMSDOC-7056: Single-source and add test scenarios chapters in the upstream document.

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/TestScenarioEditor-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/TestScenarioEditor-section.adoc
@@ -14,6 +14,10 @@ include::test-designer-latest-version-test-proc.adoc[leveloffset=+2]
 include::test-designer-view-hide-alerts-con.adoc[leveloffset=+2]
 include::test-designer-contextual-menu-ref.adoc[leveloffset=+2]
 
+include::test-designer-global-settings-panel-con.adoc[leveloffset=+1]
+include::test-designer-global-settings-panel-rule-based-proc.adoc[leveloffset=+2]
+include::test-designer-global-settings-panel-dmn-based-proc.adoc[leveloffset=+2]
+
 include::test-designer-create-test-scenario-template-con.adoc[leveloffset=+1]
 include::test-designer-create-test-template-rule-based-proc.adoc[leveloffset=+2]
 include::test-designer-alias-proc.adoc[leveloffset=+2]
@@ -40,6 +44,10 @@ include::test-scenarios-running-locally-proc.adoc[leveloffset=+1]
 include::test-designer-test-scenario-export-import-spreadsheet-con.adoc[leveloffset=+1]
 include::test-designer-test-scenario-export-spreadsheet-proc.adoc[leveloffset=+2]
 include::test-designer-test-scenario-import-spreadsheet-proc.adoc[leveloffset=+2]
+
+include::test-scenarios-coverage-report-con.adoc[leveloffset=+1]
+include::test-scenarios-coverage-report-rule-based-proc.adoc[leveloffset=+2]
+include::test-scenarios-coverage-report-dmn-based-proc.adoc[leveloffset=+2]
 
 include::test-designer-create-mortgages-example-proc.adoc[leveloffset=+1]
 

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-designer-global-settings-panel-con.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-designer-global-settings-panel-con.adoc
@@ -1,4 +1,4 @@
-[id='test-designer-global-settings-panel-con']
+[id='test-designer-global-settings-panel-con_{context}']
 = Global settings for test scenarios
 
 You can use the global *Settings* tab on the right side of the test scenarios designer to set and modify the additional properties of assets.

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-designer-global-settings-panel-dmn-based-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-designer-global-settings-panel-dmn-based-proc.adoc
@@ -1,4 +1,4 @@
-[id='test-designer-global-settings-panel-dmn-based-proc']
+[id='test-designer-global-settings-panel-dmn-based-proc_{context}']
 = Configuring global settings for DMN-based test scenarios
 
 Follow the procedure below to view and edit the global settings of DMN-based test scenarios.

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-designer-global-settings-panel-rule-based-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-designer-global-settings-panel-rule-based-proc.adoc
@@ -1,4 +1,4 @@
-[id='test-designer-global-settings-panel-rule-based-proc']
+[id='test-designer-global-settings-panel-rule-based-proc_{context}']
 = Configuring global settings for rule-based test scenarios
 
 Follow the procedure below to view and edit the global settings of rule-based test scenarios.

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-comparison-legacy-new-ref.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-comparison-legacy-new-ref.adoc
@@ -102,7 +102,7 @@ a|*Rule flow group*
 
 a|
 
-* For more information about setting rule flow group in new test scenarios, see xref:test-designer-global-settings-panel-rule-based-proc[].
+* For more information about setting rule flow group in new test scenarios, see xref:test-designer-global-settings-panel-rule-based-proc_{context}[].
 * For more information about setting rule flow group in test scenarios (legacy), xref:test-scenarios-legacy-GIVEN-proc[].
 
 a|*Global variables*

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-comparison-legacy-new-ref.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-comparison-legacy-new-ref.adoc
@@ -102,7 +102,7 @@ a|*Rule flow group*
 
 a|
 
-* For more information about setting rule flow group in new test scenarios, see xref:test-designer-global-settings-panel-rule-based-proc_{context}[].
+* For more information about setting rule flow group in new test scenarios, see xref:test-designer-global-settings-panel-rule-based-proc_test-scenarios[].
 * For more information about setting rule flow group in test scenarios (legacy), xref:test-scenarios-legacy-GIVEN-proc[].
 
 a|*Global variables*

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-coverage-report-con.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-coverage-report-con.adoc
@@ -1,4 +1,4 @@
-[id='test-scenarios-coverage-report-con']
+[id='test-scenarios-coverage-report-con_{context}']
 = Coverage reports for test scenarios
 
 The test scenario designer provides a clear and coherent way of displaying the test coverage statistics using the *Coverage Report* tab on the right side of the test scenario designer. You can also download the coverage report to view and analyze the test coverage statistics. Downloaded test scenario coverage report supports the `.CSV` file format. For more information about the RFC specification for the Comma-Separated Values (CSV) format, see https://tools.ietf.org/html/rfc4180[Common Format and MIME Type for Comma-Separated Values (CSV) Files].

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-coverage-report-dmn-based-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-coverage-report-dmn-based-proc.adoc
@@ -1,4 +1,4 @@
-[id='test-scenarios-coverage-report-dmn-based-proc']
+[id='test-scenarios-coverage-report-dmn-based-proc_{context}']
 = Generating coverage reports for DMN-based test scenarios
 
 In DMN-based test scenarios, the *Coverage Report* tab contains the detailed information about the following:

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-coverage-report-rule-based-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-coverage-report-rule-based-proc.adoc
@@ -1,4 +1,4 @@
-[id='test-scenarios-coverage-report-rule-based-proc']
+[id='test-scenarios-coverage-report-rule-based-proc_{context}']
 = Generating coverage reports for rule-based test scenarios
 
 In rule-based test scenarios, the *Coverage Report* tab contains the detailed information about the following:


### PR DESCRIPTION
**JIRAs:**
- [Epic](https://issues.redhat.com/browse/BXMSDOC-6749)
- [Associated JIRA](https://issues.redhat.com/browse/BXMSDOC-7056)

**Enterprise document previews:**
- [RHPAM-Testing a decision service using test scenarios](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-7056-RHPAM-TS/#test-designer-global-settings-panel-con_test-scenarios)
- [RHDM-Testing a decision service using test scenarios](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-7056-RHDM-TS/#test-designer-global-settings-panel-con_test-scenarios)

**Drools community document preview** 
Please check the following chapters from drools doc:
- [16.12.2. Global settings for test scenarios](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-7056-Drools-Doc/#test-designer-global-settings-panel-con_drl-rules)
- [16.12.12. Coverage reports for test scenarios](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-7056-Drools-Doc/#test-scenarios-coverage-report-con_drl-rules)
